### PR TITLE
No more workaround

### DIFF
--- a/src/Sixel_CModule.jl
+++ b/src/Sixel_CModule.jl
@@ -156,7 +156,7 @@ const sixel_output_t = sixel_output
 const sixel_write_function = Ptr{Cvoid}
 
 function sixel_output_new(output, fn_write, priv, allocator)
-    ccall((:sixel_output_new, libsixel), SIXELSTATUS, (Ptr{Ptr{sixel_output_t}}, sixel_write_function, Ptr{Cvoid}, Ptr{sixel_allocator_t}), output, fn_write, priv, allocator)
+    ccall((:sixel_output_new, libsixel), SIXELSTATUS, (Ptr{Ptr{sixel_output_t}}, sixel_write_function, Any, Ptr{sixel_allocator_t}), output, fn_write, priv, allocator)
 end
 
 function sixel_output_create(fn_write, priv)

--- a/src/encoder.jl
+++ b/src/encoder.jl
@@ -21,10 +21,11 @@ function SixelEncoder(io::IO, img::AbstractArray)
     SixelEncoder(io, colorbits, pixelformat, allocator)
 end
 
-function sixel_write_callback_function(buffer_ptr::Ptr{Cchar}, sz::Cint, priv)::Cint
-    io = unsafe_load(priv)
-    buffer = unsafe_wrap(Vector{Cchar}, buffer_ptr, (sz, ))
-    return Cint(write(io, buffer))
+function sixel_write_callback_function(buffer_ptr::Ptr{Cchar}, sz::Cint, priv::Ref{T}) where {T<:IO}
+    io = unsafe_load(Base.unsafe_convert(Ptr{T}, priv))
+    buffer = unsafe_wrap(Array{Cchar}, buffer_ptr, (sz, ))
+    write(io, buffer)
+    return Cint(C.SIXEL_OK)
 end
 
 function (enc::SixelEncoder{T})(img::AbstractMatrix; transpose=true) where {T<:IO}


### PR DESCRIPTION
Passing the type `T` through the parametric type annotation should be fine.