### PR TITLE
add FileIO support

### DIFF
--- a/src/Sixel.jl
+++ b/src/Sixel.jl
@@ -32,6 +32,8 @@ default_decoder() = LibSixel.LibSixelDecoder()
 include("encoder.jl")
 include("decoder.jl")
 
+# various frontend and input type supports
+include("frontend/fileio.jl")
 
 # Ref: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
 """

--- a/src/backend/libsixel/decoder.jl
+++ b/src/backend/libsixel/decoder.jl
@@ -26,12 +26,17 @@ function (dec::LibSixelDecoder)(bytes::Vector{UInt8}; transpose=false)
     )
     check_status(status)
 
+    palette_length = 256
+    ncolors[] <= palette_length || throw(ArgumentError("palette `ncolors` should be less than $(palette_length), instead it is $(ncolors[])"))
+
     index = unsafe_wrap(Matrix{Cuchar}, pixels[], (pwidth[], pheight[]); own=false)
 
     # libsixel declares it to be ARGB but it's actually RGB{N0f8}
     PT = RGB{N0f8}
     pvalues = convert(Ptr{PT}, palette[])
-    values = unsafe_wrap(Vector{PT}, pvalues, (ncolors[], ); own=false)
+    # TODO: we can acutally further compress the data with `values` of length `ncolors`
+    #       Does it worth it? Maybe, but not very much, though.
+    values = unsafe_wrap(Vector{PT}, pvalues, (palette_length, ); own=false)
     values = OffsetArray(values, OffsetArrays.Origin(0)) # again, libsixel assumes 0-based indexing
 
     return index, values

--- a/src/frontend/fileio.jl
+++ b/src/frontend/fileio.jl
@@ -1,0 +1,27 @@
+using FileIO
+
+function fileio_load(f::File{format"SIXEL"}; kwargs...)
+    open(f, "r") do io
+        sixel_decode(io)
+    end
+end
+
+function fileio_load(io::Stream{format"SIXEL"}; kwargs...)
+    sixel_decode(RGB{N0f8}, io; kwargs...)
+end
+
+sixel_decode(::Type{T}, io::Stream{format"SIXEL"}, dec::SDC=default_decoder(); kwargs...) where T =
+    sixel_decode(T, io.io, dec; kwargs...)
+
+function fileio_save(f::File{format"SIXEL"}, img::AbstractArray; kwargs...)
+    open(f, "w") do io
+        sixel_encode(io, img; kwargs...)
+    end
+end
+
+function fileio_save(io::Stream{format"SIXEL"}, img::AbstractArray; kwargs...)
+    sixel_encode(io, img; kwargs...)
+end
+
+sixel_encode(io::Stream{format"SIXEL"}, img::AbstractArray, enc::SEC=default_encoder(img); kwargs...) =
+    sixel_encode(io.io, img, enc; kwargs...)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+FileIO = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
 ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 ImageIO = "82e4d734-157c-48bb-816b-45c225c6df19"
 ImageMagick = "6218d12a-5da1-5696-b52f-db25d2ecc6d1"

--- a/test/fileio.jl
+++ b/test/fileio.jl
@@ -1,0 +1,14 @@
+@testset "fileio" begin
+    tmp_file = tempname() * ".sixel"
+    for img in (
+        repeat(Gray.(0:0.1:0.9), inner=(10, 50)),
+        repeat(RGB.(0:0.1:0.9), inner=(10, 50))
+    )
+        save(tmp_file, img)
+        img_readback = load(tmp_file)
+        @test eltype(img_readback) == RGB{N0f8}
+        @test img_readback isa IndirectArray
+
+        @test assess_psnr(img, eltype(img).(img_readback)) > 30
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,9 @@
 using Sixel
 using Test
-using ImageCore, IndirectArrays, TestImages
+using ImageCore, IndirectArrays
 using ImageQualityIndexes
 using LinearAlgebra
+using FileIO, TestImages
 
 sixel_output = Sixel.is_sixel_supported()
 sixel_output || @info "Current terminal does not support sixel format sequence. Display tests to stdout will be marked as broken."
@@ -16,4 +17,5 @@ end
 
 @testset "Sixel.jl" begin
     include("backend/libsixel.jl")
+    # include("fileio.jl") # need upstream registration
 end


### PR DESCRIPTION
I've commented out the test, but have tested the script using a modified FileIO version.

@IanButterworth Given that `ImageMagick` also supports sixel format(I just realize this...), it makes sense to me to also register this package in ImageIO.

A small benchmark on `load("cameraman.six")` shows that `Sixel.jl` is more performant than `ImageMagick.jl`:

```julia
img = testimage("cameraman");

@btime save("cameraman.six", img);
# Sixel: 17.870 ms (101 allocations: 261.22 KiB)
# ImageMagick: 68.960 ms (583 allocations: 813.92 KiB)

@btime load("cameraman.six");
# Sixel: 2.628 ms (107 allocations: 180.41 KiB)
# ImageMagick: 13.318 ms (620 allocations: 9.05 MiB)